### PR TITLE
Screenshot flash default

### DIFF
--- a/examples/export_figure.py
+++ b/examples/export_figure.py
@@ -101,7 +101,7 @@ viewer.scale_bar.length = 250
 # are not in the exported figure.
 viewer.theme = "light"
 # Optionally for saving the exported figure: viewer.export_figure(path="export_figure.png")
-export_figure = viewer.export_figure(flash=False) # bug: default flash=True causes the canvas to be grayscale in docs
+export_figure = viewer.export_figure(flash=False)
 scaled_export_figure = viewer.export_figure(scale_factor=5, flash=False)
 viewer.theme = "dark"
 

--- a/examples/export_figure.py
+++ b/examples/export_figure.py
@@ -101,8 +101,8 @@ viewer.scale_bar.length = 250
 # are not in the exported figure.
 viewer.theme = "light"
 # Optionally for saving the exported figure: viewer.export_figure(path="export_figure.png")
-export_figure = viewer.export_figure(flash=False)
-scaled_export_figure = viewer.export_figure(scale_factor=5, flash=False)
+export_figure = viewer.export_figure()
+scaled_export_figure = viewer.export_figure(scale_factor=5)
 viewer.theme = "dark"
 
 viewer.add_image(export_figure, rgb=True, name='exported_figure')

--- a/examples/screenshot_and_export_figure.py
+++ b/examples/screenshot_and_export_figure.py
@@ -59,8 +59,8 @@ viewer.scale_bar.box = True
 # Take screenshots and export figures in 'light' theme, to show the canvas
 # margins and the extent of the exported figure.
 viewer.theme = 'light'
-screenshot = viewer.screenshot(flash=False)
-figure = viewer.export_figure(flash=False)
+screenshot = viewer.screenshot()
+figure = viewer.export_figure()
 # optionally, save the exported figure: viewer.export_figure(path='export_figure.png')
 # or screenshot: viewer.screenshot(path='screenshot.png')
 
@@ -68,15 +68,15 @@ figure = viewer.export_figure(flash=False)
 # Zoom in and take another screenshot and export figure to show the different
 # extents of the exported figure and screenshot.
 viewer.camera.zoom = 3
-screenshot_zoomed = viewer.screenshot(flash=False)
-figure_zoomed = viewer.export_figure(flash=False)
+screenshot_zoomed = viewer.screenshot()
+figure_zoomed = viewer.export_figure()
 
 
 # Remove the layer that exists outside the image extent and take another
 # figure export to show the extent of the exported figure without the
 # layer that exists outside the camera image extent.
 viewer.layers.remove(layer_outside)
-figure_no_outside_shape = viewer.export_figure(flash=False)
+figure_no_outside_shape = viewer.export_figure()
 
 
 # Display the screenshots and figures in 'dark' theme, and switch to grid mode

--- a/examples/screenshot_and_export_figure.py
+++ b/examples/screenshot_and_export_figure.py
@@ -59,7 +59,7 @@ viewer.scale_bar.box = True
 # Take screenshots and export figures in 'light' theme, to show the canvas
 # margins and the extent of the exported figure.
 viewer.theme = 'light'
-screenshot = viewer.screenshot(flash=False) # bug: default flash=True causes the canvas to be grayscale in docs
+screenshot = viewer.screenshot(flash=False)
 figure = viewer.export_figure(flash=False)
 # optionally, save the exported figure: viewer.export_figure(path='export_figure.png')
 # or screenshot: viewer.screenshot(path='screenshot.png')

--- a/examples/to_screenshot.py
+++ b/examples/to_screenshot.py
@@ -126,7 +126,7 @@ pos[:, 1, 1] = 2 * radius_space * np.sin(phi_space)
 layer = viewer.add_vectors(pos, edge_width=2)
 
 # take screenshot
-screenshot = viewer.screenshot(flash=False) # bug: default flash=True causes the canvas to be grayscale in docs
+screenshot = viewer.screenshot(flash=False)
 viewer.add_image(screenshot, rgb=True, name='screenshot')
 
 # from skimage.io import imsave

--- a/examples/to_screenshot.py
+++ b/examples/to_screenshot.py
@@ -126,7 +126,7 @@ pos[:, 1, 1] = 2 * radius_space * np.sin(phi_space)
 layer = viewer.add_vectors(pos, edge_width=2)
 
 # take screenshot
-screenshot = viewer.screenshot(flash=False)
+screenshot = viewer.screenshot()
 viewer.add_image(screenshot, rgb=True, name='screenshot')
 
 # from skimage.io import imsave

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1781,7 +1781,7 @@ class Window:
             imsave(path, img)
         return img
 
-    def clipboard(self, flash=False, canvas_only=False):
+    def clipboard(self, flash=True, canvas_only=False):
         """Copy screenshot of current viewer to the clipboard.
 
         Parameters

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1588,7 +1588,7 @@ class Window:
         self,
         size: Optional[tuple[int, int]] = None,
         scale: Optional[float] = None,
-        flash: bool = True,
+        flash: bool = False,
         canvas_only: bool = False,
         fit_to_data_extent: bool = False,
     ) -> 'QImage':

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1588,7 +1588,7 @@ class Window:
         self,
         size: Optional[tuple[int, int]] = None,
         scale: Optional[float] = None,
-        flash: bool = False,
+        flash: bool = True,
         canvas_only: bool = False,
         fit_to_data_extent: bool = False,
     ) -> 'QImage':
@@ -1781,7 +1781,7 @@ class Window:
             imsave(path, img)
         return img
 
-    def clipboard(self, flash=True, canvas_only=False):
+    def clipboard(self, flash=False, canvas_only=False):
         """Copy screenshot of current viewer to the clipboard.
 
         Parameters

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -174,18 +174,29 @@ def test_screenshot(make_napari_viewer, qtbot):
     viewer.add_shapes(data)
 
     # Take screenshot of the image canvas only
-    screenshot = viewer.screenshot(canvas_only=True, flash=False)
+    # Check that by default there is no flash animation
+    screenshot = viewer.screenshot(canvas_only=True)
     assert screenshot.ndim == 3
+    assert not hasattr(
+        viewer.window._qt_viewer._welcome_widget, '_flash_animation'
+    )
 
     # Take screenshot with the viewer included
-    screenshot = viewer.screenshot(canvas_only=False, flash=False)
+    screenshot = viewer.screenshot(canvas_only=False)
     assert screenshot.ndim == 3
 
     # test size argument (and ensure it coerces to int)
     screenshot = viewer.screenshot(canvas_only=True, size=(20, 20.0))
     assert screenshot.shape == (20, 20, 4)
-    # Here we wait until the flash animation will be over. We cannot wait on finished
-    # signal as _flash_animation may be already removed when calling wait.
+
+    # Test that the flash argument works
+    screenshot = viewer.screenshot(canvas_only=True, flash=True)
+    assert hasattr(
+        viewer.window._qt_viewer._welcome_widget, '_flash_animation'
+    )
+
+    # Here we wait until the flash animation will be over prior to teardown.
+    # We cannot wait on finished signal as _flash_animation may be already removed when calling wait.
     qtbot.waitUntil(
         lambda: not hasattr(
             viewer.window._qt_viewer._welcome_widget, '_flash_animation'

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -95,7 +95,7 @@ class Viewer(ViewerModel):
         path: Optional[str] = None,
         *,
         scale_factor: float = 1,
-        flash: bool = True,
+        flash: bool = False,
     ) -> np.ndarray:
         """Export an image of the full extent of the displayed layer data.
 
@@ -129,7 +129,7 @@ class Viewer(ViewerModel):
             each layer.
         flash : bool
             Flag to indicate whether flash animation should be shown after
-            the screenshot was captured. By default, True.
+            the screenshot was captured. By default, False.
 
         Returns
         -------
@@ -150,7 +150,7 @@ class Viewer(ViewerModel):
         size: Optional[tuple[str, str]] = None,
         scale: Optional[float] = None,
         canvas_only: bool = True,
-        flash: bool = True,
+        flash: bool = False,
     ):
         """Take currently displayed screen and convert to an image array.
 
@@ -171,7 +171,7 @@ class Viewer(ViewerModel):
         flash : bool
             Flag to indicate whether flash animation should be shown after
             the screenshot was captured.
-            By default, True.
+            By default, False.
 
         Returns
         -------


### PR DESCRIPTION
# References and relevant issues

- [ ] Should defaults in qt_main_window.py:  _QtMainWindow._screenshot, screenshot, clipboard be changed?
- [ ] Should defaults in qt_viewer.py: QtViewer._screenshot, screenshot, clipboard be changed?
- [ ] Should explicit `flash=False` references in tests be removed? I think it is ok to keep. 
- [x] One test updated to now add flash
- [x] Turn `flash=False` as default in viewer.py `Viewer` methods.
- [] Look into _file.py and QtViewer._screenshot_dialog --> this is where screenshot, screenshot, clipboard are

I think from what I gather, functions in QtViewer and _QtMainWindow are accessed by the file menu links, so these should be kept to True 

So ultimately, there is Viewer (the 'public' api), Window, and QtViewer. the public methods call the viewer.window method anyways, so these are just conveniences. Thus, turn these conveniences to false since recommended usage in documentation. Would expect that less naive users would only access Window and QtViewer
Need to remove explicit flash = false in examples

_file.py uses QtViewer and Window methods. So Viewer is safe to make edits on without changing GUI functionality. 