### PR TITLE
Fix to have warnings from thread_worker work and errors not error

### DIFF
--- a/src/napari/_qt/qthreading.py
+++ b/src/napari/_qt/qthreading.py
@@ -52,11 +52,11 @@ _S = TypeVar('_S')
 _R = TypeVar('_R')
 
 
-class FunctionWorker(_qthreading.FunctionWorker[_R], _NotifyingMixin): ...
+class FunctionWorker(_NotifyingMixin, _qthreading.FunctionWorker[_R]): ...
 
 
 class GeneratorWorker(
-    _qthreading.GeneratorWorker[_Y, _S, _R], _NotifyingMixin
+    _NotifyingMixin, _qthreading.GeneratorWorker[_Y, _S, _R]
 ): ...
 
 
@@ -212,12 +212,16 @@ def create_worker(
         )
         worker.errored.connect(
             partial(
-                lambda task_status_id, function: window._update_task_status(
-                    task_status_id,
-                    Status.FAILED,
-                    description=trans._(
-                        '{func} execution failed', deferred=True, func=function
-                    ),
+                lambda task_status_id, function, exc: (
+                    window._update_task_status(
+                        task_status_id,
+                        Status.FAILED,
+                        description=trans._(
+                            '{func} execution failed',
+                            deferred=True,
+                            func=function,
+                        ),
+                    )
                 ),
                 worker_status_id,
                 func,


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari/pull/8914#issuecomment-4309944183

I asked Claude to investigate why clicking the thread_worker warning didn't do anything and why I got an extra Error when clicking the thread_worker error.

From Claude:
```
 Summary

  I've successfully fixed the two issues in the message_routing.py example:

  Issue 1: Thread worker warning button does nothing

  Root Cause: The _NotifyingMixin.__init__ method was not being called due to
  incorrect Python MRO (Method Resolution Order). The warned signal was never
  connected to the _relay_warning method.

  Fix: Changed the class definition order in src/napari/_qt/qthreading.py:

   - Before: class FunctionWorker(_qthreading.FunctionWorker[_R], _NotifyingMixin): 
  ...
   - After: class FunctionWorker(_NotifyingMixin, _qthreading.FunctionWorker[_R]): 
  ...

  This ensures _NotifyingMixin.__init__ is called first in the MRO chain, which
  properly connects the warned signal to the _relay_warning method.

  Issue 2: Thread worker error button causes TypeError

  Root Cause: The errored signal emits an exception object as an argument, but the
  lambda function in worker.errored.connect() was only expecting 2 arguments (which
  came from partial).

  Fix: Updated the lambda to accept the exception argument:

   - Before: lambda task_status_id, function: ...
   - After: lambda task_status_id, function, exc: ...

  The exc parameter captures the exception emitted by the signal, preventing the
  "TypeError: create_worker.<locals>.<lambda>() takes 2 positional arguments but 3
  were given" error.

  Changes Made:

   1. File: /Users/piotrsobolewski/Dev/napari/src/napari/_qt/qthreading.py
    - Line 55: Reordered FunctionWorker inheritance
    - Line 58-59: Reordered GeneratorWorker inheritance
    - Line 215: Added exc parameter to lambda

  Verification:

   - All 18 threading and worker-related tests pass
   - Manual testing confirms both warning and error notifications are properly 
  displayed
   - No regressions in existing functionality
  
```

Take it or leave it, I wanted to record it somewhere.