### PR TITLE
Mnt/citation

### DIFF
--- a/.github/workflows/citation_cff_validate.yml
+++ b/.github/workflows/citation_cff_validate.yml
@@ -21,5 +21,16 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Python
+        uses: actions/setup-python@42375524ee3024772d2619547bf164f1345f7471 # v5.4.0
+        with:
+          python-version: '3.13'
+
+      - name: Install checker dependency
+        run: python -m pip install PyYAML>=6.0
+
+      - name: Check CITATION.cff author ordering
+        run: python tools/check_citation_authors.py check-order
+
       - name: Validate CITATION.cff
         uses: dieghernan/cff-validator@114aae53e1850c3757733beb60036941900e3dc3 # v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,14 @@ repos:
     exclude: .*\.py
 - repo: local
   hooks:
+  - id: check-citation-author-order
+    name: check CITATION.cff author ordering
+    language: python
+    additional_dependencies:
+    - PyYAML>=6.0
+    entry: python tools/check_citation_authors.py check-order
+    pass_filenames: false
+    files: ^CITATION.cff$
   - id: check-groups-vs-extras
     name: check that all group names in pyproject.toml are in extras
     language: python

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,7 @@ identifiers:
 - type: doi
   value: 10.5281/zenodo.3555620
 authors:
+# Current and emeritus core team members.
 - given-names: Nicholas
   family-names: Sofroniew
   affiliation: Chan Zuckerberg Initiative
@@ -55,6 +56,16 @@ authors:
   family-names: Yamauchi
   affiliation: Iber Lab - ETH Zürich
   alias: kevinyamauchi
+- given-names: Justine
+  family-names: Larsen
+  alias: justinelarsen
+- given-names: Shannon
+  family-names: Axelrod
+  alias: shanaxel42
+- given-names: Ziyang
+  family-names: Liu
+  affiliation: Chan Zuckerberg Initiative Foundation
+  alias: liu-ziyang
 - given-names: Melissa
   family-names: Weber Mendonça
   affiliation: Quansight
@@ -112,6 +123,7 @@ authors:
   affiliation: Chan Zuckerberg Initiative
   orcid: https://orcid.org/0000-0002-7237-1973
   alias: kephale
+# Community contributors, alphabetized by family-names.
 - given-names: Jacopo
   family-names: Abramo
   affiliation: Leibniz-IPHT, Jena, Germany
@@ -146,7 +158,7 @@ authors:
   family-names: Annex
   affiliation: SETI Institute/NASA ARC
   orcid: https://orcid.org/0000-0002-0253-2313
-  alias:  AndrewAnnex
+  alias: AndrewAnnex
 - given-names: Constantin
   family-names: Aronssohn
   orcid: https://orcid.org/0009-0008-5607-9463
@@ -156,14 +168,14 @@ authors:
   affiliation: University of California, Santa Cruz
   orcid: https://orcid.org/0000-0002-4172-4676
   alias: FilBalza
-- given-names: Peter
-  family-names: Boone
-  alias: boonepeter
 - given-names: Kresimir
   family-names: Bestak
   affiliation: Heidelberg University, Germany
   orcid: https://orcid.org/0009-0009-8245-9846
   alias: kbestak
+- given-names: Peter
+  family-names: Boone
+  alias: boonepeter
 - given-names: Jordão
   family-names: Bragantini
   affiliation: Chan Zuckerberg Biohub
@@ -268,6 +280,11 @@ authors:
   affiliation: University College London
   orcid: https://orcid.org/0000-0002-9788-7263
   alias: sdiebolt
+- given-names: Marcelo
+  family-names: Leomil Zoccoler
+  affiliation: Katana Labs
+  orcid: https://orcid.org/0000-0002-6165-4679
+  alias: zoccoler
 - given-names: Gregor
   family-names: Lichtner
   affiliation: Universitätsmedizin Greifswald
@@ -278,10 +295,6 @@ authors:
   affiliation: Kobe University
   orcid: https://orcid.org/0009-0006-5724-8121
   alias: hanjinliu
-- given-names: Ziyang
-  family-names: Liu
-  affiliation: Chan Zuckerberg Initiative Foundation
-  alias: liu-ziyang
 - given-names: Alan
   family-names: Lowe
   affiliation: UCL & The Alan Turing Institute
@@ -319,16 +332,16 @@ authors:
   affiliation: Sainsbury Wellcome Centre - University College London
   orcid: https://orcid.org/0000-0001-6363-1545
   alias: sfmig
-- given-names: Hector
-  family-names: Muñoz
-  affiliation: University of California, Los Angeles
-  orcid: https://orcid.org/0000-0001-7851-2549
-  alias: hectormz
 - given-names: Jan-Hendrik
   family-names: Müller
   affiliation: Georg-August-Universität Göttingen
   orcid: https://orcid.org/0009-0007-3670-9969
   alias: kolibril13
+- given-names: Hector
+  family-names: Muñoz
+  affiliation: University of California, Los Angeles
+  orcid: https://orcid.org/0000-0001-7851-2549
+  alias: hectormz
 - given-names: Christopher
   family-names: Nauroth-Kreß
   affiliation: University Hospital Würzburg - Institute of Neuroradiology
@@ -353,24 +366,19 @@ authors:
   affiliation: Georg-August-Universität Göttingen
   orcid: https://orcid.org/0000-0001-6562-7187
   alias: constantinpape
-- given-names: Eric
-  family-names: Perlman
-  affiliation: Yikes LLC
-  orcid: https://orcid.org/0000-0001-5542-1302
-  alias: perlman
-- given-names: Rensu Petrus
-  family-names: Theart
-  affiliation: Department of Electrical and Electronic Engineering, Stellenbosch University
-  orcid: https://orcid.org/0000-0003-0508-1690
-  alias: rensutheart
-- given-names: Kim
-  family-names: Pevey
-  alias: kcpevey
 - given-names: Gonzalo
   family-names: Peña-Castellanos
   affiliation: Quansight
   orcid: https://orcid.org/0000-0002-1214-4680
   alias: goanpeca
+- given-names: Eric
+  family-names: Perlman
+  affiliation: Yikes LLC
+  orcid: https://orcid.org/0000-0001-5542-1302
+  alias: perlman
+- given-names: Kim
+  family-names: Pevey
+  alias: kcpevey
 - given-names: Jasper
   family-names: Phelps
   affiliation: EPFL
@@ -430,6 +438,11 @@ authors:
   affiliation: Houston Methodist Research Institute
   orcid: https://orcid.org/0000-0001-7815-7014
   alias: wulinteousa2-hash
+- given-names: Rensu Petrus
+  family-names: Theart
+  affiliation: Department of Electrical and Electronic Engineering, Stellenbosch University
+  orcid: https://orcid.org/0000-0003-0508-1690
+  alias: rensutheart
 - given-names: Jules
   family-names: Vanaret
   affiliation: Aix Marseille University, CNRS, Fresnel, I2M, IBDM, Turing Centre for Living systems
@@ -453,6 +466,16 @@ authors:
   family-names: Winston
   affiliation: Tobeva Software
   alias: pwinston
+- given-names: Guillaume
+  family-names: Witz
+  affiliation: Data Science Lab, University of Bern, Switzerland
+  orcid: https://orcid.org/0000-0003-1562-4265
+  alias: guiwitz
+- given-names: Aniket Singh
+  family-names: Yadav
+  affiliation: Galgotias University
+  orcid: https://orcid.org/0009-0004-4883-3797
+  alias: Aniketsy
 - given-names: Qin
   family-names: Yu
   affiliation: European Molecular Biology Laboratory (EMBL)
@@ -468,20 +491,5 @@ authors:
   affiliation: Chinese Academy of Sciences - SIAT, Shenzhen, China
   orcid: https://orcid.org/0009-0005-8264-5682
   alias: BeanLi
-- given-names: Guillaume
-  family-names: Witz
-  affiliation: Data Science Lab, University of Bern, Switzerland
-  orcid: https://orcid.org/0000-0003-1562-4265
-  alias: guiwitz
-- given-names: Marcelo
-  family-names: Leomil Zoccoler
-  affiliation: Katana Labs
-  orcid: https://orcid.org/0000-0002-6165-4679
-  alias: zoccoler
-- given-names: Aniket Singh
-  family-names: Yadav
-  affiliation: Galgotias University
-  orcid: https://orcid.org/0009-0004-4883-3797
-  alias: Aniketsy
 repository-code: https://github.com/napari/napari
 license: BSD-3-Clause

--- a/tools/check_citation_authors.py
+++ b/tools/check_citation_authors.py
@@ -1,0 +1,388 @@
+"""Utilities for maintaining napari's CITATION.cff author list.
+
+Usage:
+    python tools/check_citation_authors.py check-order
+        Validate that community contributors remain alphabetized by
+        ``family-names`` after the core-team section marker.
+
+    python tools/check_citation_authors.py write-order
+        Rewrite only the community-contributor section into the expected
+        alphabetical order. The core-team block is preserved as-is.
+
+    python tools/check_citation_authors.py audit-missing [--issue-body]
+        Compare GitHub contributors for ``napari/napari`` against the
+        ``alias`` values in ``CITATION.cff`` and print either the missing
+        usernames or a ready-to-paste issue body with ``@mentions``.
+
+Notes:
+    - The top block in ``CITATION.cff`` is an explicitly maintained core-team
+      section. This script does not alphabetize or otherwise reorder that block.
+    - The boundary between the core-team block and the community block is the
+      comment line ``# Community contributors, alphabetized by family-names.``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import unicodedata
+from itertools import pairwise
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CITATION_CFF = REPO_ROOT / 'CITATION.cff'
+CORE_TEAM_COMMENT = 'Current and emeritus core team members.'
+COMMUNITY_COMMENT = 'Community contributors, alphabetized by family-names.'
+KNOWN_BOT_LOGINS = {
+    'app/dependabot',
+    'dependabot[bot]',
+    'github-actions[bot]',
+    'napari-bot',
+    'pre-commit-ci[bot]',
+    'renovate[bot]',
+}
+
+
+def configure_stdio() -> None:
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, 'reconfigure', None)
+        if reconfigure is not None:
+            reconfigure(encoding='utf-8', errors='backslashreplace')
+
+
+def load_citation_data(path: Path = CITATION_CFF) -> dict:
+    return yaml.safe_load(path.read_text(encoding='utf-8'))
+
+
+def normalize_sort_value(value: str) -> str:
+    collapsed = ' '.join(value.split())
+    decomposed = unicodedata.normalize('NFKD', collapsed.casefold())
+    return ''.join(
+        char for char in decomposed if not unicodedata.combining(char)
+    )
+
+
+def author_label(author: dict) -> str:
+    given_names = author.get('given-names', '').strip()
+    family_names = author.get('family-names', '').strip()
+    alias = author.get('alias', '').strip()
+    return f'{family_names}, {given_names} ({alias})'
+
+
+def author_sort_key(author: dict) -> tuple[str, str, str]:
+    return (
+        normalize_sort_value(author.get('family-names', '')),
+        normalize_sort_value(author.get('given-names', '')),
+        normalize_sort_value(author.get('alias', '')),
+    )
+
+
+def get_authors(data: dict) -> list[dict]:
+    authors = data.get('authors')
+    if not isinstance(authors, list):
+        raise TypeError('CITATION.cff must contain an authors list.')
+    return authors
+
+
+def check_order(path: Path = CITATION_CFF) -> int:
+    _, _, community, _ = split_citation_author_sections(path)
+    for index, (current, following) in enumerate(
+        pairwise(community),
+        start=1,
+    ):
+        if author_sort_key(current) > author_sort_key(following):
+            print(
+                'Community contributors in CITATION.cff must be alphabetized by '
+                'family-names after the core-team section marker.',
+                file=sys.stderr,
+            )
+            print(
+                f'Out-of-order community pair #{index} and #{index + 1}: '
+                f'{author_label(current)} should sort after '
+                f'{author_label(following)}.',
+                file=sys.stderr,
+            )
+            return 1
+
+    print('CITATION.cff author ordering is valid.')
+    return 0
+
+
+def load_author_from_block(block: str) -> dict:
+    payload = yaml.safe_load(block)
+    if not isinstance(payload, list) or len(payload) != 1:
+        raise ValueError(
+            'Each author block in CITATION.cff must contain one author.'
+        )
+    author = payload[0]
+    if not isinstance(author, dict):
+        raise TypeError(
+            'Each author block in CITATION.cff must parse as a mapping.'
+        )
+    return author
+
+
+def _split_author_blocks(lines: list[str]) -> list[str]:
+    blocks: list[str] = []
+    current_block: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith('#'):
+            continue
+        if line.startswith('- '):
+            if current_block:
+                blocks.append(''.join(current_block))
+            current_block = [line]
+            continue
+        if not current_block:
+            raise ValueError(
+                'Found non-author content inside the authors section.'
+            )
+        current_block.append(line)
+
+    if current_block:
+        blocks.append(''.join(current_block))
+    return blocks
+
+
+def split_citation_author_sections(
+    path: Path,
+) -> tuple[list[str], list[dict], list[dict], list[str]]:
+    lines = path.read_text(encoding='utf-8').splitlines(keepends=True)
+
+    try:
+        authors_index = next(
+            index
+            for index, line in enumerate(lines)
+            if line.startswith('authors:')
+        )
+    except StopIteration as error:
+        raise ValueError(
+            'CITATION.cff does not contain an authors section.'
+        ) from error
+
+    suffix_index = len(lines)
+    for index in range(authors_index + 1, len(lines)):
+        line = lines[index]
+        if line.strip() and not line.startswith((' ', '-', '\t', '#')):
+            suffix_index = index
+            break
+
+    prefix_lines = lines[: authors_index + 1]
+    author_lines = lines[authors_index + 1 : suffix_index]
+    suffix_lines = lines[suffix_index:]
+
+    try:
+        community_index = next(
+            index
+            for index, line in enumerate(author_lines)
+            if line.strip() == f'# {COMMUNITY_COMMENT}'
+        )
+    except StopIteration as error:
+        raise ValueError(
+            'CITATION.cff must contain a community section marker line: '
+            f'# {COMMUNITY_COMMENT}'
+        ) from error
+
+    core_lines = author_lines[:community_index]
+    community_lines = author_lines[community_index + 1 :]
+    core_authors = [
+        load_author_from_block(block)
+        for block in _split_author_blocks(core_lines)
+    ]
+    community_authors = [
+        load_author_from_block(block)
+        for block in _split_author_blocks(community_lines)
+    ]
+    return prefix_lines, core_authors, community_authors, suffix_lines
+
+
+def build_author_block(author: dict) -> str:
+    return yaml.safe_dump(
+        [author],
+        allow_unicode=True,
+        sort_keys=False,
+        default_flow_style=False,
+    )
+
+
+def write_order(path: Path = CITATION_CFF) -> int:
+    prefix_lines, core_authors, community_authors, suffix_lines = (
+        split_citation_author_sections(path)
+    )
+    sorted_community = sorted(community_authors, key=author_sort_key)
+    new_text = (
+        ''.join(prefix_lines)
+        + f'# {CORE_TEAM_COMMENT}\n'
+        + ''.join(build_author_block(author) for author in core_authors)
+        + f'# {COMMUNITY_COMMENT}\n'
+        + ''.join(build_author_block(author) for author in sorted_community)
+        + ''.join(suffix_lines)
+    )
+
+    if path.read_text(encoding='utf-8') == new_text:
+        print('CITATION.cff author order already matches the project policy.')
+        return 0
+
+    path.write_text(new_text, encoding='utf-8')
+    print(f'Reordered community contributors in {path}.')
+    return 0
+
+
+def github_login_key(login: str) -> str:
+    return normalize_sort_value(login)
+
+
+def is_bot_login(login: str) -> bool:
+    return login in KNOWN_BOT_LOGINS or login.endswith('[bot]')
+
+
+def fetch_github_contributors(repo: str) -> list[str]:
+    result = subprocess.run(
+        [
+            'gh',
+            'api',
+            f'repos/{repo}/contributors',
+            '--paginate',
+            '--slurp',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or 'Unknown gh api error.'
+        raise RuntimeError(f'Failed to fetch GitHub contributors: {stderr}')
+
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, list):
+        raise TypeError('Unexpected GitHub API response for contributors.')
+
+    seen: set[str] = set()
+    contributors: list[str] = []
+    for page in payload:
+        if not isinstance(page, list):
+            raise TypeError(
+                'Unexpected GitHub API page while reading contributors.'
+            )
+        for item in page:
+            login = item.get('login') if isinstance(item, dict) else None
+            if not isinstance(login, str):
+                continue
+            if is_bot_login(login):
+                continue
+            normalized = github_login_key(login)
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            contributors.append(login)
+    return contributors
+
+
+def missing_contributors(path: Path, repo: str) -> list[str]:
+    authors = get_authors(load_citation_data(path))
+    aliases = {
+        github_login_key(author.get('alias', ''))
+        for author in authors
+        if isinstance(author.get('alias'), str)
+        and author.get('alias', '').strip()
+    }
+    return [
+        login
+        for login in fetch_github_contributors(repo)
+        if github_login_key(login) not in aliases
+    ]
+
+
+def format_issue_body(logins: list[str], repo: str) -> str:
+    mentions = ' '.join(f'@{login}' for login in logins)
+    lines = [
+        'The following GitHub contributors appear to have commits in '
+        f'{repo} but do not currently have an `alias` entry in `CITATION.cff`.',
+        '',
+        'If you would like to be included, please open a PR that adds your '
+        'entry in alphabetical order by `family-names` within the community '
+        'contributor section.',
+        '',
+        mentions or '(No missing contributors found.)',
+    ]
+    return '\n'.join(lines)
+
+
+def audit_missing(path: Path, repo: str, issue_body: bool) -> int:
+    try:
+        logins = missing_contributors(path, repo)
+    except RuntimeError as error:
+        print(str(error), file=sys.stderr)
+        return 1
+
+    if issue_body:
+        print(format_issue_body(logins, repo))
+        return 0
+
+    if not logins:
+        print('All GitHub contributors are represented in CITATION.cff.')
+        return 0
+
+    print('GitHub contributors missing from CITATION.cff:')
+    for login in logins:
+        print(login)
+    return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--citation-path',
+        type=Path,
+        default=CITATION_CFF,
+        help='Path to the CITATION.cff file to inspect.',
+    )
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    subparsers.add_parser('check-order', help='Validate author ordering.')
+    subparsers.add_parser(
+        'write-order',
+        help='Rewrite community contributors into the expected sorted order.',
+    )
+
+    audit_parser = subparsers.add_parser(
+        'audit-missing',
+        help='Report GitHub contributors missing from CITATION.cff aliases.',
+    )
+    audit_parser.add_argument(
+        '--repo',
+        default='napari/napari',
+        help='GitHub repository in owner/name format.',
+    )
+    audit_parser.add_argument(
+        '--issue-body',
+        action='store_true',
+        help='Print a ready-to-paste GitHub issue body with @mentions.',
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    configure_stdio()
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == 'check-order':
+        return check_order(args.citation_path)
+    if args.command == 'write-order':
+        return write_order(args.citation_path)
+    if args.command == 'audit-missing':
+        return audit_missing(args.citation_path, args.repo, args.issue_body)
+
+    parser.error(f'Unsupported command: {args.command}')
+    return 2
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
# Description

This PR primarily adds a script that can be used as a pre-commit hook and in CI in order to make sure that the CITATION file is properly ordered. I've noticed lately that when we ask authors to add themselves to the CITATION file, even with the "alphabetize by family name" their lovely LLM decides to add it ... wherever. I don't think it's worth being tedious about it in new contributor PRs, _so_ this script/pre-commit hook intends to fight someone else's lovely bot with our own bot. Because I don't think it's worth that much time, I generated the script with Copilot / GPT5.4 -- but I did try to validate it as much as possible. 

The script has a few functions, but will mostly be used for its hook with `python tools/check_citation_authors.py check-order` to validate alphabetizes by last name.

1. `check-order` uses the new comments in CITATION to split the "core contributor" (we need to discuss how this is ordered LOL) and "community contributors" (alphabetized). It will then make sure that the community section is ordered by last name, and raise a warning if now.
2. I then generated the updated CITATION file with `write-order`
3. `audit-missing` It also has something I've wanted for a while, a way to go back and give folks one opportunity to add themselves to CITATION with an open issue, if they've been missed over the years as its _possible_ that we are the reason they were missed -- especially without a clear policy previously. The result of this would ping the following list (eyeballing like 80+ folks?):
```raw
@117chief @grlee77 @nclack @mstabrin @haesleinhuepf @rahul713rk @chili-chiu @codemonkey800 @tdimino @cwood1967 
@mkitti @neuromusic @pranathivemuri @RDIL @sammyhansali @manzt @truatpasteurdotfr @2dx @jakirkham @clbarnes 
@arokem @beanli161514 @AJFSalomon @zeroth @bryantChhun @DanGonite57 @glyg @NHPatterson @ianhi @isabela-pf 
@jojoelfe @8bitbiscuit @kandarpksk @liaprins-czi @marshuang80 @NicolasCARPi @harripj @pierrethibault @RobAnKo 
@rpanderson @Cryaaa @samcunliffe @wconnell @nweisenfeld @Llewi @MaksHess @matthias-us @mrocklin @marlene09 
@MarcoGorelli @MBPhys @lukasvasadi @nhthayer @laysauchoa @dongyaoli10x @danieldegroot2 @akuten1298 @Zac-HD 
@wadhikar @will-moore @VasudhaJha @UmbWill @ttung @thanushipeiris @Mishrasubha @stefanv @manics @zindy 
@DenisSch @d-v-b @ddawsari @danielballan @ctrueden @cjwatson @camlloyd @cajongonzales @BhavyaC16 @aaristov 
@ahuang11 @AmirAflak @ekdnam @vigji @leopold-franz @kushaangupta @joshmoore @jcfr @jczech @eltociear @hugovk 
@gcadenazzi @floryst @Fifourche @edoumazane @elena-pascal

```
4. Finally, I manually audited the core team section, noting that Justine Larson, Shannon Axelrod, and Ziyang Liu are all emeritus core team members that were not in the core team section.